### PR TITLE
[ISSUE-49] Closes #49 by fixing race condition

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -220,3 +220,10 @@ tasks:
       - task: build
       - task: test
       - task: coverage
+
+  test-suite:
+    desc: Run all tests
+    cmds:
+      - task: test
+      - task: integration
+      - task: bench


### PR DESCRIPTION
This change fixes a race condition in the storage manager.  It also adds a new `test-suite` task command so that it tests all of the tests at once.